### PR TITLE
Upgrade Spark scripts for Dataproc v1.1 and Spark v2.

### DIFF
--- a/pyspark/app_collaborative.py
+++ b/pyspark/app_collaborative.py
@@ -53,14 +53,13 @@ TABLE_RECOMMENDATIONS = "Recommendation"
 # Read the data from the Cloud SQL
 # Create dataframes
 #[START read_from_sql]
-jdbcDriver = 'com.mysql.jdbc.Driver'
 jdbcUrl    = 'jdbc:mysql://%s:3306/%s?user=%s&password=%s' % (CLOUDSQL_INSTANCE_IP, CLOUDSQL_DB_NAME, CLOUDSQL_USER, CLOUDSQL_PWD)
-dfAccos = sqlContext.load(source='jdbc', driver=jdbcDriver, url=jdbcUrl, dbtable=TABLE_ITEMS)
-dfRates = sqlContext.load(source='jdbc', driver=jdbcDriver, url=jdbcUrl, dbtable=TABLE_RATINGS)
+dfAccos = sqlContext.read.jdbc(url=jdbcUrl, table=TABLE_ITEMS)
+dfRates = sqlContext.read.jdbc(url=jdbcUrl, table=TABLE_RATINGS)
 #[END read_from_sql]
 
 # Get all the ratings rows of our user
-dfUserRatings  = dfRates.filter(dfRates.userId == USER_ID).map(lambda r: r.accoId).collect()
+dfUserRatings  = dfRates.filter(dfRates.userId == USER_ID).rdd.map(lambda r: r.accoId).collect()
 print(dfUserRatings)
 
 # Returns only the accommodations that have not been rated by our user

--- a/pyspark/find_model_collaborative.py
+++ b/pyspark/find_model_collaborative.py
@@ -33,7 +33,6 @@ conf = SparkConf().setAppName("app_collaborative")
 sc = SparkContext(conf=conf)
 sqlContext = SQLContext(sc)
 
-jdbcDriver = 'com.mysql.jdbc.Driver'
 jdbcUrl    = 'jdbc:mysql://%s:3306/%s?user=%s&password=%s' % (CLOUDSQL_INSTANCE_IP, CLOUDSQL_DB_NAME, CLOUDSQL_USER, CLOUDSQL_PWD)
 
 #[START how_far]
@@ -57,7 +56,7 @@ def howFarAreWe(model, against, sizeAgainst):
 
 # Read the data from the Cloud SQL
 # Create dataframes
-dfRates = sqlContext.load(source='jdbc', driver=jdbcDriver, url=jdbcUrl, dbtable='Rating')
+dfRates = sqlContext.read.jdbc(url=jdbcUrl, table='Rating')
 
 rddUserRatings = dfRates.filter(dfRates.userId == 0).rdd
 print(rddUserRatings.count())


### PR DESCRIPTION
The Spark scripts weren't working properly anymore with new clusters created with Cloud Dataproc 1.1 (released 08/08/2016) due to the use of some methods that were recently removed in Spark v2 (see [1] and [2]).

[1] https://github.com/apache/spark/commit/77ab49b8575d2ebd678065fa70b0343d532ab9c2
[2] https://github.com/apache/spark/commit/4dd24811d9035c52c5965fca2fc6431aac6963fc

Note: This should also fix #9 